### PR TITLE
Include number of active sessions in Stop-Sessions

### DIFF
--- a/client/twamp_test_worker.cpp
+++ b/client/twamp_test_worker.cpp
@@ -225,6 +225,8 @@ void TwampTestWorker::sendControlStopSessions()
     struct twamp_message_stop_sessions stop_sessions;
     memset(&stop_sessions, 0, sizeof(struct twamp_message_stop_sessions));
     stop_sessions.three = 3;
+    quint32 number_of_sessions = 1;
+    qToBigEndian(number_of_sessions, (uchar *)&stop_sessions.number_of_sessions);
     controlSocket->write((const char*)&stop_sessions, sizeof(stop_sessions));
     status = HandshakeStopSession;
     emit twampLog(TwampLogPacket, "", QByteArray((const char*)&stop_sessions, sizeof(stop_sessions)), HandshakeStopSession);


### PR DESCRIPTION
Based on RFC5357 responder expects the correct number of
active sessions in Stop-Sessions packet:

   Number of Sessions indicates the number of sessions that the
   Control-Client intends to stop.

   Number of Sessions MUST contain the number of send sessions started
   by the Control-Client that have not been previously terminated by a
   Stop-Sessions command (i.e., the Control-Client MUST account for each
   accepted Request-Session).  If the Stop-Sessions message does not
   account for exactly the number of sessions in progress, then it is to
   be considered invalid, the TWAMP-Control connection SHOULD be closed,
   and any results obtained considered invalid.