### PR TITLE
Fix error estimate handling in test packets

### DIFF
--- a/client/twamp_test_worker.cpp
+++ b/client/twamp_test_worker.cpp
@@ -260,10 +260,7 @@ void TwampTestWorker::udpSendTimerDone()
     qToBigEndian(sequence, (uchar*)&message->sequence_number);
     qToBigEndian(now.seconds, (uchar*)&message->timestamp.seconds);
     qToBigEndian(now.fraction, (uchar*)&message->timestamp.fraction);
-    message->error_estimate.s = 0;
-    message->error_estimate.z = 0;
-    message->error_estimate.scale = 0;
-    message->error_estimate.multiplier = 1;
+    message->error_estimate = TwampCommon::getErrorEstimate();
 
     sequence++;
 

--- a/common/twamp_common.h
+++ b/common/twamp_common.h
@@ -191,6 +191,7 @@ public:
     struct twamp_time getTwampTime();
     int twampTimeToTimeval (struct twamp_time *time, struct timeval *result);
     float timevalDiff (struct timeval *before, struct timeval *after);
+    struct twamp_message_error_estimate getErrorEstimate();
     static QString toHex(const QByteArray &data);
     static QString toHex(const char *data, unsigned int length);
     static QString acceptString(uint8_t accept);

--- a/responder/twamp_responder_worker.cpp
+++ b/responder/twamp_responder_worker.cpp
@@ -393,6 +393,8 @@ void TwampResponderWorker::clientTestPacketRead()
     response->sender_sequence_number = msg->sequence_number;
     response->sender_timestamp.seconds = msg->timestamp.seconds;
     response->sender_timestamp.fraction = msg->timestamp.fraction;
+    response->sender_error_estimate = msg->error_estimate;
+    response->error_estimate = TwampCommon::getErrorEstimate();
 
     socket->writeDatagram((const char*)outbuf, sizeof(outbuf), client->controlSocket->peerAddress(), client->testUdpPort);
     emit twampLog(TwampLogPacket, "", QByteArray((const char*)outbuf, sizeof(outbuf)), TestPacketSent);


### PR DESCRIPTION
Try to use ntp_adjtime to get error estimate on Linux