### PR TITLE
Packet TTL info not available, use Sender TTL = 255

### DIFF
--- a/responder/twamp_responder_worker.cpp
+++ b/responder/twamp_responder_worker.cpp
@@ -391,6 +391,7 @@ void TwampResponderWorker::clientTestPacketRead()
     qToBigEndian(received.seconds, (uchar*)&response->receive_timestamp.seconds);
     qToBigEndian(received.fraction, (uchar*)&response->receive_timestamp.fraction);
     response->sender_sequence_number = msg->sequence_number;
+    response->sender_ttl = 255;
     response->sender_timestamp.seconds = msg->timestamp.seconds;
     response->sender_timestamp.fraction = msg->timestamp.fraction;
     response->sender_error_estimate = msg->error_estimate;


### PR DESCRIPTION
4.2.  Reflector Behavior

   -  Extract the Sender TTL value from the TTL/Hop Limit value of
      received packets.  Session-Reflector implementations SHOULD fetch
      the TTL/Hop Limit value from the IP header of the packet,
      replacing the value of 255 set by the Session-Sender.  If an
      implementation does not fetch the actual TTL value (the only good
      reason not to do so is an inability to access the TTL field of
      arriving packets), it MUST set the Sender TTL value as 255.