### PR TITLE
Generate a random SID in Accept-Session message

### DIFF
--- a/responder/twamp_responder_worker.cpp
+++ b/responder/twamp_responder_worker.cpp
@@ -281,6 +281,9 @@ void TwampResponderWorker::sendAcceptSession(Client *client, quint16 prefferedPo
     memset(&accept, 0, sizeof(accept));
     accept.accept = 0;
     qToBigEndian(socket->localPort(), (uchar*)&accept.port);
+    for (int i = 0; i < 16; i++) {
+        accept.sid.sid[i] = qrand() & 0xFF;
+    }
 
     connect(socket, SIGNAL(readyRead()), this, SLOT(clientTestPacketRead()));
 


### PR DESCRIPTION
3.5.  Creating Test Sessions

   The Session Identifier (SID) is as defined in OWAMP [RFC4656].  Since
   the SID is always generated by the receiving side, the Server
   determines the SID, and the SID in the Request-TW-Session message
   MUST be set to 0.