### PR TITLE
Convert error estimate to big endian before send

### DIFF
--- a/responder/twamp_responder_worker.cpp
+++ b/responder/twamp_responder_worker.cpp
@@ -398,7 +398,7 @@ void TwampResponderWorker::clientTestPacketRead()
     response->sender_timestamp.seconds = msg->timestamp.seconds;
     response->sender_timestamp.fraction = msg->timestamp.fraction;
     response->sender_error_estimate = msg->error_estimate;
-    response->error_estimate = TwampCommon::getErrorEstimate();
+    qToBigEndian(TwampCommon::getErrorEstimate(), (uchar*)&response->error_estimate);
 
     socket->writeDatagram((const char*)outbuf, sizeof(outbuf), client->controlSocket->peerAddress(), client->testUdpPort);
     emit twampLog(TwampLogPacket, "", QByteArray((const char*)outbuf, sizeof(outbuf)), TestPacketSent);


### PR DESCRIPTION
The sender gets a huge number without the conversion.